### PR TITLE
git add . -A as a release step ?

### DIFF
--- a/lib/release_package.js
+++ b/lib/release_package.js
@@ -100,10 +100,6 @@ releasePackage.execute = function (pkg, callback) {
             versionup({}, callback);
         },
         function (callback) {
-            logger.info('Pushing git changes...');
-            execCommand('git', ['add', '.', '-A'], callback);
-        },
-        function (callback) {
             var commitMsg = 'Version incremented to ' + pkg['version'];
             execCommand('git', ['commit', '-m', commitMsg], callback)
         },

--- a/lib/release_package.js
+++ b/lib/release_package.js
@@ -101,7 +101,7 @@ releasePackage.execute = function (pkg, callback) {
         },
         function (callback) {
             var commitMsg = 'Version incremented to ' + pkg['version'];
-            execCommand('git', ['commit', '-m', commitMsg], callback)
+            execCommand('git', ['commit', '-a', '-m', commitMsg], callback)
         },
         function (callback) {
             execCommand('git', ['push'], callback);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ape-releasing",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "ape framework module for releasing tasks.",
   "main": "lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ape-releasing",
-  "version": "1.0.21",
+  "version": "2.0.1",
   "description": "ape framework module for releasing tasks.",
   "main": "lib",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ape-releasing",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "ape framework module for releasing tasks.",
   "main": "lib",
   "scripts": {


### PR DESCRIPTION
Hi,

Recently I've faced the issue that ape-releasing is adding to the git repo each and every file  of the current working directory to the git repo which includes the npm_modules directory.

I believe that, a valid answer is those files which we do not want to add to the repo must be defined into the .gitignore file.

At the other side I am dealing with 50+ devs where the risk of  keeping the git ignore file up to date is bigger.

From other point of view, the release procedure should release only files which have been present into the repo and avoid releasing / adding files created by release / test procedure.

I am open to have the change as a option if you think it is better approach.

Cheers
